### PR TITLE
Bump labeler to v5.0.0 and update config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -12,8 +12,10 @@ chore:
 
 documentation:
   - head-branch: ['^docs/', '^doc/']
-  - changed-files: '**/*.md'
+  - changed-files:
+    - any-glob-to-any-file: '**/*.md'
 
 dependencies:
   - head-branch: ['^deps/', '^dep/', '^dependabot/']
-  - changed-files: ['go.mod', 'go.sum']
+  - changed-files:
+    - any-glob-to-any-file: ['go.mod', 'go.sum']

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,6 +12,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/labeler@v5.0.0-alpha.1
+      - uses: actions/labeler@v5.0.0
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          sync-labels: true


### PR DESCRIPTION
Updates labeler action and its configuration to use https://github.com/actions/labeler/releases/tag/v5.0.0
